### PR TITLE
Include property name in error messages

### DIFF
--- a/lib/Workflow/OperationType/Command.pm
+++ b/lib/Workflow/OperationType/Command.pm
@@ -381,7 +381,7 @@ sub call {
         die "Undefined value returned from $command_name->create\n" . join("\n", @errors) . "\n";
     }
 
-    @errors = map { "$command_name: Error " . $_->desc } $command->__errors__;
+    @errors = map { "$command_name: " . join(', ', $_->properties) . ": Error " . $_->desc } $command->__errors__;
     if (@errors) {
         die join("\n",@errors);
     }

--- a/lib/Workflow/OperationType/Command.pm
+++ b/lib/Workflow/OperationType/Command.pm
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 
 use Time::HiRes;
+use Workflow;
 use Workflow::Instrumentation qw(timing);
 
 class Workflow::OperationType::Command {


### PR DESCRIPTION
A common error is "No value specified for required property" which is
not revealing when the applicable property is not identified.