### PR TITLE
add valid_signals

### DIFF
--- a/lib/Workflow/DataSource/PausableRDBMS.pm
+++ b/lib/Workflow/DataSource/PausableRDBMS.pm
@@ -4,6 +4,7 @@ use Workflow;
 
 class Workflow::DataSource::PausableRDBMS {
     doc => 'Mixin class to implement pausing access to the database',
+    valid_signals => [qw( precommit precreate_handle query sequence_nextval )],
 };
 
 my $query_pause = _make_db_pause_function('query_pause_sentry_file_path');


### PR DESCRIPTION
An upcoming change to UR fixes a bug in the signal validation code that 
exposes cases where a class did not define `valid_signals` nor a
`validate_subscription` method.  This is one such example.